### PR TITLE
Fix neon block animation

### DIFF
--- a/textures/flipbook_textures.json
+++ b/textures/flipbook_textures.json
@@ -2,6 +2,6 @@
   {
     "flipbook_texture": "textures/blocks/neon_block",
     "atlas_tile": "neon_block",
-    "ticks_per_frame": 4
+    "ticks_per_frame": 10
   }
 ]


### PR DESCRIPTION
The animation of the neon block is too fast. It was 10 ticks before.